### PR TITLE
Port available mods to typer

### DIFF
--- a/osu.Game.Rulesets.Typer/Mods/TyperModCinema.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModCinema.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Typer.Objects;
+using osu.Game.Rulesets.Typer.Replays;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModCinema : ModCinema<TyperHitObject>
+    {
+        public override ModReplayData CreateReplayData(IBeatmap beatmap, IReadOnlyList<Mod> mods)
+            => new ModReplayData(new TyperAutoGenerator(beatmap).Generate(), new ModCreatedUser { Username = "sample" });
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModDaycore.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModDaycore.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModDaycore : ModDaycore
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModDoubleTime.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModDoubleTime.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModDoubleTime : ModDoubleTime
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModHalfTime.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModHalfTime.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModHalfTime : ModHalfTime
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModMuted.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModMuted.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Typer.Objects;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModMuted : ModMuted<TyperHitObject>
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModNightcore.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModNightcore.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Typer.Objects;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModNightcore : ModNightcore<TyperHitObject>
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModNoFail.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModNoFail.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModNoFail : ModNoFail
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModPerfect.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModPerfect.cs
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModPerfect : ModPerfect
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/Mods/TyperModSuddenDeath.cs
+++ b/osu.Game.Rulesets.Typer/Mods/TyperModSuddenDeath.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Game.Rulesets.Mods;
+
+namespace osu.Game.Rulesets.Typer.Mods
+{
+    public class TyperModSuddenDeath : ModSuddenDeath
+    {
+    }
+}

--- a/osu.Game.Rulesets.Typer/TyperRuleset.cs
+++ b/osu.Game.Rulesets.Typer/TyperRuleset.cs
@@ -12,8 +12,10 @@ using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Typer.Beatmaps;
 using osu.Game.Rulesets.Typer.Mods;
+using osu.Game.Rulesets.Typer.Beatmaps;
 using osu.Game.Rulesets.Typer.UI;
 using osu.Game.Rulesets.UI;
+using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Rulesets.Typer
 {
@@ -31,8 +33,26 @@ namespace osu.Game.Rulesets.Typer
         {
             switch (type)
             {
+                case ModType.DifficultyReduction:
+                    return new Mod[]
+                    {
+                        new TyperModNoFail(),
+                        new MultiMod(new TyperModHalfTime(), new TyperModDaycore()),
+                    };
+
+                case ModType.DifficultyIncrease:
+                    return new Mod[]
+                    {
+                        new MultiMod(new TyperModSuddenDeath(), new TyperModPerfect()),
+                        new MultiMod(new TyperModDoubleTime(), new TyperModNightcore()),
+                    };
+
                 case ModType.Automation:
-                    return new[] { new TyperModAutoplay() };
+                    return new Mod[]
+                    {
+                        new TyperModAutoplay(),
+                        new TyperModCinema(),
+                    };
 
                 default:
                     return Array.Empty<Mod>();

--- a/osu.Game.Rulesets.Typer/TyperRuleset.cs
+++ b/osu.Game.Rulesets.Typer/TyperRuleset.cs
@@ -45,19 +45,21 @@ namespace osu.Game.Rulesets.Typer
                     {
                         new MultiMod(new TyperModSuddenDeath(), new TyperModPerfect()),
                         new MultiMod(new TyperModDoubleTime(), new TyperModNightcore()),
+                        new ModAccuracyChallenge(),
                     };
 
                 case ModType.Automation:
                     return new Mod[]
                     {
-                        new TyperModAutoplay(),
-                        new TyperModCinema(),
+                        new MultiMod(new TyperModAutoplay(), new TyperModCinema()),
                     };
 
                 case ModType.Fun:
                     return new Mod[]
                     {
+                        new MultiMod(new ModWindUp(), new ModWindDown()),
                         new TyperModMuted(),
+                        new ModAdaptiveSpeed(),
                     };
 
                 default:

--- a/osu.Game.Rulesets.Typer/TyperRuleset.cs
+++ b/osu.Game.Rulesets.Typer/TyperRuleset.cs
@@ -54,6 +54,12 @@ namespace osu.Game.Rulesets.Typer
                         new TyperModCinema(),
                     };
 
+                case ModType.Fun:
+                    return new Mod[]
+                    {
+                        new TyperModMuted(),
+                    };
+
                 default:
                     return Array.Empty<Mod>();
             }


### PR DESCRIPTION
There are some mods we can directly use in Typer:

- NoFail
- SuddenDeath & Perfect
- Speed changing mods (HT/DC/DT/NC)
- Cinema
- Muted
- Some newly added mods (AC, Fun mods)

Now they can be included and ready for use.
