### PR TITLE
Fix visual HitBox positioning issue

### DIFF
--- a/osu.Game.Rulesets.Typer/TyperRuleset.cs
+++ b/osu.Game.Rulesets.Typer/TyperRuleset.cs
@@ -12,10 +12,8 @@ using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Typer.Beatmaps;
 using osu.Game.Rulesets.Typer.Mods;
-using osu.Game.Rulesets.Typer.Beatmaps;
 using osu.Game.Rulesets.Typer.UI;
 using osu.Game.Rulesets.UI;
-using osu.Game.Resources.Localisation.Web;
 
 namespace osu.Game.Rulesets.Typer
 {

--- a/osu.Game.Rulesets.Typer/UI/TyperPlayfield.cs
+++ b/osu.Game.Rulesets.Typer/UI/TyperPlayfield.cs
@@ -15,11 +15,13 @@ namespace osu.Game.Rulesets.Typer.UI
     [Cached]
     public partial class TyperPlayfield : ScrollingPlayfield
     {
+        public const float HEIGHT = 80;
+
         [BackgroundDependencyLoader]
         private void load()
         {
             RelativeSizeAxes = Axes.X;
-            Height = 80;
+            Height = HEIGHT;
 
             Anchor = Anchor.CentreLeft;
             Origin = Anchor.CentreLeft;
@@ -44,7 +46,7 @@ namespace osu.Game.Rulesets.Typer.UI
 
         public HitBox()
         {
-            Margin = new MarginPadding { Left = 40 };
+            Margin = new MarginPadding { Left = TyperPlayfield.HEIGHT / 2 };
             InternalChildren = new Drawable[]
             {
                 new OneBox(),
@@ -84,7 +86,7 @@ namespace osu.Game.Rulesets.Typer.UI
                     Hollow = true,
                 };
 
-                Size = new Vector2(80);
+                Size = new Vector2(TyperPlayfield.HEIGHT);
 
                 AddRangeInternal(new Drawable[]
                 {

--- a/osu.Game.Rulesets.Typer/UI/TyperPlayfield.cs
+++ b/osu.Game.Rulesets.Typer/UI/TyperPlayfield.cs
@@ -44,6 +44,7 @@ namespace osu.Game.Rulesets.Typer.UI
 
         public HitBox()
         {
+            Margin = new MarginPadding { Left = 40 };
             InternalChildren = new Drawable[]
             {
                 new OneBox(),


### PR DESCRIPTION
Added a padding of 40 (half of the OneBox size) to make the visual hitbox match the actual box.

Fixes #2.
